### PR TITLE
Fix zip

### DIFF
--- a/examples/web/views/dashboard.erb
+++ b/examples/web/views/dashboard.erb
@@ -38,7 +38,7 @@
     <% @orders.each do |order| %>
       <tr>
         <td><a href="/orders/<%= order.id %>"><%= order.id %></a></td>
-        <td><%= order.ship_to.name %>, <%= order.ship_to.city %>, <%= order.ship_to.state %> <%= order.ship_to.zip_code %></td>
+        <td><%= order.ship_to.name %>, <%= order.ship_to.city %>, <%= order.ship_to.state %> <%= order.ship_to.zip %></td>
         <td><%= order.status %></td>
         <td><a href="/campaigns/<%= order.campaign_id %>"><%= order.campaign.name %></a></td>
       </tr>

--- a/examples/web/views/order.erb
+++ b/examples/web/views/order.erb
@@ -104,7 +104,7 @@
   </tr>
   <tr>
     <td><strong>Zip</strong></td>
-    <td><%= @order.ship_to.zip_code %></td>
+    <td><%= @order.ship_to.zip %></td>
   </tr>
   <tr>
     <td><strong>Country</strong></td>

--- a/examples/web/views/orders.erb
+++ b/examples/web/views/orders.erb
@@ -13,7 +13,7 @@
     <% @orders.each do |order| %>
       <tr>
         <td><a href="/orders/<%= order.id %>"><%= order.id %></a></td>
-        <td><%= order.ship_to.name %>, <%= order.ship_to.city %>, <%= order.ship_to.state %> <%= order.ship_to.zip_code %></td>
+        <td><%= order.ship_to.name %>, <%= order.ship_to.city %>, <%= order.ship_to.state %> <%= order.ship_to.zip %></td>
         <td><%= order.status %></td>
         <td><a href="/campaigns/<%= order.campaign_id %>"><%= order.campaign.name %></a></td>
       </tr>

--- a/lib/printfection/address.rb
+++ b/lib/printfection/address.rb
@@ -6,7 +6,7 @@ module Printfection
     property :company
     property :city
     property :state
-    property :zip_code, from: :zip
+    property :zip
     property :country
     property :email
     property :phone

--- a/lib/printfection/version.rb
+++ b/lib/printfection/version.rb
@@ -1,4 +1,4 @@
 module Printfection
-  VERSION = "1.0.0"
+  VERSION = "1.0.2"
 end
 


### PR DESCRIPTION
Use `zip` instead of `zip_code`. I believe the `zip_code` was there for reading, but it broke serialization for order creation.

I also noticed `Printfection::VERSION` was not updated to `1.0.1` with my last fix. I went ahead and bumped it to `1.0.2`.
